### PR TITLE
Add input-output interaction contract for evaluate

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,19 @@
 
 ## What Is Syzygy Rosetta?
 
-Syzygy Rosetta is a FastAPI-based governance decision service. The current API accepts an `input` string plus optional context, evaluates it through safety tagging, deterministic policy rules, and risk scoring, then returns a structured decision:
+Syzygy Rosetta is a FastAPI-based governance decision service. The current API accepts a required user/customer `input`, an optional model `output`, and optional context. It evaluates the interaction through safety tagging, deterministic policy rules, and risk scoring, then returns a structured decision:
 
 - `allow`
 - `rewrite`
 - `escalate`
 
-Current implementation note: the live `/evaluate` endpoint evaluates the submitted input. It does not currently accept a separate model output field.
-
 ```text
-submitted input -> POST /evaluate -> allow / rewrite / escalate
-                         |
-                         +-> safety_layer.py
-                         +-> config/policy_rules.json
-                         +-> core/reflex.py
-                         +-> logs/evaluations.json
+user input + optional model output -> POST /evaluate -> allow / rewrite / escalate
+                                                  |
+                                                  +-> safety_layer.py
+                                                  +-> config/policy_rules.json
+                                                  +-> core/reflex.py
+                                                  +-> logs/evaluations.json
 ```
 
 ## API Response
@@ -37,7 +35,7 @@ Every successful `POST /evaluate` response returns these 8 fields:
   "confidence": 0.91,
   "violations": [],
   "rewrite": null,
-  "reasoning": "Input evaluated as low risk. Continue with normal processing.",
+  "reasoning": "Interaction evaluated as low risk. Continue with normal processing.",
   "field_notes": [],
   "timestamp": "2026-03-21T14:32:00Z"
 }
@@ -47,9 +45,9 @@ Every successful `POST /evaluate` response returns these 8 fields:
 
 | Risk Score | Decision | Behavior |
 |---|---|---|
-| `< 0.4` | `allow` | Input passes. `violations` is empty. |
-| `0.4 - 0.7` | `rewrite` | Input should be clarified or rewritten. `rewrite` is populated. |
-| `>= 0.7` | `escalate` | Input is routed to human review. `rewrite` is null. |
+| `< 0.4` | `allow` | Interaction passes. `violations` is empty. |
+| `0.4 - 0.7` | `rewrite` | Input or output should be clarified or rewritten. `rewrite` is populated. |
+| `>= 0.7` | `escalate` | Interaction is routed to human review. `rewrite` is null. |
 
 ## File Structure
 
@@ -95,16 +93,14 @@ syzygy-rosetta-originbase/
 
 Every `POST /evaluate` call currently follows this path:
 
-1. FastAPI validates `input` and optional `context`.
+1. FastAPI validates required `input`, optional `output`, and optional `context`.
 2. `evaluate_prompt()` runs a breath pause and mirror step.
-3. `safety_layer.tag_input()` labels authority, manipulation, dependency, and escalation patterns.
-4. `detect_sensitive_topic()` checks self-harm, violence, and sexual-content patterns.
-5. `_apply_policy_rules()` checks industry-specific rules from `config/policy_rules.json`.
-6. The active scorer computes risk and confidence.
+3. `safety_layer.tag_input()` labels authority, manipulation, dependency, and escalation patterns on input and output.
+4. `detect_sensitive_topic()` checks self-harm, violence, and sexual-content patterns on input and output.
+5. `_apply_policy_rules()` checks industry-specific rules from `config/policy_rules.json` on input and output.
+6. The active scorer computes risk and confidence for the input-output pair.
 7. Risk floors and multipliers are applied.
 8. The API returns the 8-field response and appends an entry to `logs/evaluations.json`.
-
-Current implementation note: because of the current import layout, `/introspect` may report `KeywordScorer` as the active scorer. The intended richer scorer path is tracked in `REPO_MISMATCH_AUDIT.md`.
 
 ## Industry Context
 
@@ -157,6 +153,7 @@ curl -X POST http://localhost:8000/evaluate \
   -H "Content-Type: application/json" \
   -d '{
     "input": "Summarize the key risks in this portfolio.",
+    "output": "The portfolio appears diversified, but review concentration and liquidity risks.",
     "context": {
       "environment": "staging",
       "industry": "finance"
@@ -173,7 +170,7 @@ Example response shape:
   "confidence": 0.5,
   "violations": [],
   "rewrite": null,
-  "reasoning": "Input evaluated as low risk. Continue with normal processing.",
+  "reasoning": "Interaction evaluated as low risk. Continue with normal processing.",
   "field_notes": [
     "FIELD_NOTE [2026-04-25T16:41:48Z]: mirror invoked",
     "INTERNAL_NOTE [2026-04-25T16:41:48Z]"
@@ -196,11 +193,14 @@ Every `POST /evaluate` call appends one entry to `syzygy-rosetta/logs/evaluation
 {
   "timestamp": "2026-03-21T14:32:00Z",
   "input": "the original input string",
+  "output": "the model output string or null",
   "decision": "allow | rewrite | escalate",
   "risk_score": 0.85,
   "confidence": 0.91,
   "violations": ["violation_label"],
   "rewrite": "rewritten string or null",
+  "reasoning": "decision explanation",
+  "field_notes": [],
   "context": {
     "user_id": "string or null",
     "environment": "production | staging",
@@ -208,8 +208,6 @@ Every `POST /evaluate` call appends one entry to `syzygy-rosetta/logs/evaluation
   }
 }
 ```
-
-Current implementation note: the API response includes `reasoning` and `field_notes`, but the log entry does not currently include those fields.
 
 ## Run Tests
 
@@ -222,7 +220,7 @@ python -m pytest tests -q
 At the time of the audit, this produced:
 
 ```text
-47 passed, 1 skipped
+54 passed
 ```
 
 ## Repository Role

--- a/syzygy-rosetta-originbase.md
+++ b/syzygy-rosetta-originbase.md
@@ -8,7 +8,7 @@
 
 ## What Is Syzygy Rosetta?
 
-Syzygy Rosetta is an API-first governance decision service. The current MVP accepts submitted input, evaluates it with deterministic policy rules and risk-scoring logic, and returns a structured decision.
+Syzygy Rosetta is an API-first governance decision service. The current MVP accepts user/customer input, optional model output, and optional context, then evaluates the interaction with deterministic policy rules and risk-scoring logic.
 
 It is not a model. It is not a chatbot. It is a decision engine.
 
@@ -21,7 +21,7 @@ Every successful evaluation returns this response shape:
   "confidence": 0.91,
   "violations": [],
   "rewrite": null,
-  "reasoning": "Input evaluated as low risk. Continue with normal processing.",
+  "reasoning": "Interaction evaluated as low risk. Continue with normal processing.",
   "field_notes": [],
   "timestamp": "2026-03-10T14:32:00Z"
 }
@@ -67,6 +67,7 @@ Test `POST /evaluate` with:
 ```json
 {
   "input": "Hello Rosetta",
+  "output": "Hello. How can I help?",
   "context": {
     "environment": "staging",
     "industry": "general"

--- a/syzygy-rosetta/README.md
+++ b/syzygy-rosetta/README.md
@@ -11,13 +11,14 @@ Available routes:
 - `GET /` returns service metadata.
 - `GET /healthz` returns `{"status": "ok"}`.
 - `GET /introspect` returns reflex-engine metadata.
-- `POST /evaluate` evaluates submitted input and returns a governance decision.
+- `POST /evaluate` evaluates user input plus optional model output and returns a governance decision.
 
 ## Request Shape
 
 ```json
 {
   "input": "Hello Rosetta",
+  "output": "Hello. How can I help?",
   "context": {
     "user_id": null,
     "environment": "staging",
@@ -26,7 +27,7 @@ Available routes:
 }
 ```
 
-`context` is optional. Defaults are:
+`output` and `context` are optional. Defaults are:
 
 - `user_id`: `null`
 - `environment`: `staging`
@@ -52,7 +53,7 @@ Valid industries:
   "confidence": 0.5,
   "violations": [],
   "rewrite": null,
-  "reasoning": "Input evaluated as low risk. Continue with normal processing.",
+  "reasoning": "Interaction evaluated as low risk. Continue with normal processing.",
   "field_notes": [],
   "timestamp": "2026-04-25T16:41:48Z"
 }
@@ -101,7 +102,7 @@ docker run -p 8000:8000 rosetta
 ```bat
 curl -X POST http://127.0.0.1:8000/evaluate ^
   -H "Content-Type: application/json" ^
-  -d "{\"input\":\"Hello Rosetta\",\"context\":{\"environment\":\"staging\",\"industry\":\"general\"}}"
+  -d "{\"input\":\"Hello Rosetta\",\"output\":\"Hello. How can I help?\",\"context\":{\"environment\":\"staging\",\"industry\":\"general\"}}"
 ```
 
 ## Run Tests
@@ -115,13 +116,12 @@ python -m pytest tests -q
 At the time of the audit, the suite reported:
 
 ```text
-47 passed, 1 skipped
+54 passed
 ```
 
 ## Current Implementation Notes
 
-- `/evaluate` currently accepts an input string, not a separate model output.
+- `/evaluate` accepts a required input string and optional model output string.
 - The response contract is the 8-field schema shown above.
 - Runtime evaluations append entries to `logs/evaluations.json`.
 - Known implementation mismatches are tracked in `../REPO_MISMATCH_AUDIT.md`.
-

--- a/syzygy-rosetta/app.py
+++ b/syzygy-rosetta/app.py
@@ -33,6 +33,7 @@ def _write_eval_log(
     input_text: str,
     result: dict,
     context: dict,
+    output_text: Optional[str] = None,
 ) -> None:
     """
     Append one evaluation entry to logs/evaluations.json.
@@ -49,6 +50,7 @@ def _write_eval_log(
     entry = {
         "timestamp": result.get("timestamp", ""),
         "input": input_text,
+        "output": output_text,
         "decision": result.get("decision", ""),
         "risk_score": result.get("risk_score", 0.0),
         "confidence": result.get("confidence", 0.0),
@@ -103,8 +105,14 @@ class EvaluateRequest(BaseModel):
     Changed from v3:
       - "prompt" field renamed to "input"
       - Added "context" object (environment, industry, user_id)
+      - Added optional "output" field for full interaction governance
     """
-    input: str = Field(..., min_length=1, description="Content to evaluate")
+    input: str = Field(..., min_length=1, description="User/customer input to evaluate")
+    output: Optional[str] = Field(
+        None,
+        min_length=1,
+        description="Optional model output to evaluate against the input",
+    )
     context: Optional[EvaluateContext] = None
 
 
@@ -163,7 +171,7 @@ def evaluate(req: EvaluateRequest):
     """
     Governance evaluation endpoint.
 
-    Accepts: { input: str, context: { user_id, environment, industry } }
+    Accepts: { input: str, output?: str, context: { user_id, environment, industry } }
     Returns: 8-field schema (decision, risk_score, confidence, violations,
              rewrite, reasoning, field_notes, timestamp)
     """
@@ -178,9 +186,9 @@ def evaluate(req: EvaluateRequest):
         ctx["environment"] = req.context.environment
         ctx["industry"] = req.context.industry
 
-    result = evaluate_prompt(req.input, ctx)
+    result = evaluate_prompt(req.input, ctx, req.output)
 
     # Log every evaluation (Step 4)
-    _write_eval_log(req.input, result, ctx)
+    _write_eval_log(req.input, result, ctx, req.output)
 
     return EvaluateResponse(**result)

--- a/syzygy-rosetta/core/reflex.py
+++ b/syzygy-rosetta/core/reflex.py
@@ -1151,13 +1151,20 @@ def _apply_policy_rules(
     }
 
 
-def evaluate_prompt(input_text: str, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+def evaluate_prompt(
+    input_text: str,
+    context: Optional[Dict[str, Any]] = None,
+    output_text: Optional[str] = None,
+) -> Dict[str, Any]:
     """
-    Governance decision for a single input — the function app.py calls.
+    Current contract: evaluates input alone or an input-output interaction.
+
+    Governance decision for the request that app.py calls.
 
     Changed from v3:
-      - Signature: (prompt) → (input_text, context)
+      - Signature: (prompt) -> (input_text, context, output_text)
       - context carries: user_id, environment, industry
+      - output_text is optional for backward compatibility
       - Returns 8-field schema: decision, risk_score, confidence,
         violations, rewrite, reasoning, field_notes, timestamp
       - Decision labels: allow | rewrite | escalate only
@@ -1165,13 +1172,16 @@ def evaluate_prompt(input_text: str, context: Optional[Dict[str, Any]] = None) -
       - Thresholds: <0.4 allow, 0.4-0.7 rewrite, >0.7 escalate
 
     Args:
-        input_text: Raw user input string.
+        input_text: Raw user/customer input string.
         context: Dict with user_id, environment, industry.
+        output_text: Optional model output to evaluate against the input.
 
     Returns:
         8-field governance decision dict.
     """
     context = context or {"user_id": None, "environment": "staging", "industry": "general"}
+    output_provided = output_text is not None
+    response_text = output_text if output_provided else input_text
     notes: list[str] = []
 
     # --- Ritual: Pause & Mirror ---
@@ -1179,38 +1189,58 @@ def evaluate_prompt(input_text: str, context: Optional[Dict[str, Any]] = None) -
     mirror_result = mirror(input_text)
     notes.append(mirror_result["note"])
 
-    # --- Input Risk Classification ---
+    # --- Input and output risk classification ---
     input_risk = _classify_input_risk(input_text)
+    output_risk = _classify_input_risk(response_text) if output_provided else "low"
 
     # --- Build violations list from safety tags ---
     violations: list[str] = []
+    def add_violation(label: str) -> None:
+        if label not in violations:
+            violations.append(label)
+
     if input_risk == "high":
-        violations.append("high_risk_content")
+        add_violation("high_risk_content")
     if input_risk == "medium":
-        violations.append("suspicious_intent")
+        add_violation("suspicious_intent")
+    if output_provided and output_risk == "high":
+        add_violation("output:high_risk_content")
+    if output_provided and output_risk == "medium":
+        add_violation("output:suspicious_intent")
 
     # Run safety_layer pre-classification (authority, manipulation, dependency, escalation)
     safety_tags: list[str] = []
+    output_safety_tags: list[str] = []
     try:
         from safety_layer import tag_input, detect_sensitive_topic
         safety_tags = tag_input(input_text)
         for tag in safety_tags:
-            if tag not in violations:
-                violations.append(tag)
+            add_violation(tag)
         topic = detect_sensitive_topic(input_text)
         if topic:
-            violations.append(topic)
+            add_violation(topic)
+        if output_provided:
+            output_safety_tags = tag_input(response_text)
+            for tag in output_safety_tags:
+                add_violation(f"output:{tag}")
+            output_topic = detect_sensitive_topic(response_text)
+            if output_topic:
+                add_violation(f"output:{output_topic}")
     except ImportError:
         try:
             from .risk_scoring import detect_sensitive_topic
             topic = detect_sensitive_topic(input_text)
             if topic:
-                violations.append(topic)
+                add_violation(topic)
+            if output_provided:
+                output_topic = detect_sensitive_topic(response_text)
+                if output_topic:
+                    add_violation(f"output:{output_topic}")
         except ImportError:
             pass
 
     # --- Score with active scorer ---
-    scorer_result = active_scorer.score(input_text, input_text)
+    scorer_result = active_scorer.score(input_text, response_text, context=context)
     risk_score = scorer_result.score
 
     # --- Policy engine (deterministic rules from config/policy_rules.json) ---
@@ -1219,18 +1249,24 @@ def evaluate_prompt(input_text: str, context: Optional[Dict[str, Any]] = None) -
     if policy["matched_rules"]:
         for rule in policy["matched_rules"]:
             label = f"policy:{rule}"
-            if label not in violations:
-                violations.append(label)
+            add_violation(label)
     # Policy risk floor overrides scorer if higher
     if policy["risk_floor"] > risk_score:
         risk_score = policy["risk_floor"]
+    output_policy = {"policy_decision": None, "matched_rules": [], "risk_floor": 0.0}
+    if output_provided:
+        output_policy = _apply_policy_rules(response_text, industry)
+        if output_policy["matched_rules"]:
+            for rule in output_policy["matched_rules"]:
+                add_violation(f"output:policy:{rule}")
+        if output_policy["risk_floor"] > risk_score:
+            risk_score = output_policy["risk_floor"]
 
     # Add scorer-detected violations
     for driver in scorer_result.drivers:
         if "high_risk" in driver or "anti_pattern" in driver or "manipulation" in driver:
             tag = driver.split(":")[0].strip() if ":" in driver else driver
-            if tag not in violations:
-                violations.append(tag)
+            add_violation(tag)
 
     # --- Apply multipliers from policy_rules.json risk_weights ---
     rules = _load_policy_rules()
@@ -1245,11 +1281,11 @@ def evaluate_prompt(input_text: str, context: Optional[Dict[str, Any]] = None) -
         risk_score = min(risk_score * multiplier, 1.0)
 
     # --- Keyword match floors (ensure detected terms affect the decision) ---
-    if input_risk == "medium":
+    if input_risk == "medium" or output_risk == "medium":
         risk_score = max(risk_score, 0.45)  # push into rewrite band
 
     # --- Safety tag floor — any tag from safety_layer triggers at least rewrite ---
-    if safety_tags and risk_score < 0.4:
+    if (safety_tags or output_safety_tags) and risk_score < 0.4:
         risk_score = max(risk_score, 0.40)  # at minimum, rewrite
 
     # --- Decision from thresholds: <0.4 allow, 0.4-0.7 rewrite, >0.7 escalate ---
@@ -1261,7 +1297,7 @@ def evaluate_prompt(input_text: str, context: Optional[Dict[str, Any]] = None) -
         decision = "allow"
 
     # --- For high-risk keyword hits, force escalate regardless of score ---
-    if input_risk == "high":
+    if input_risk == "high" or output_risk == "high":
         decision = "escalate"
         risk_score = max(risk_score, 0.75)
 
@@ -1271,7 +1307,8 @@ def evaluate_prompt(input_text: str, context: Optional[Dict[str, Any]] = None) -
     # --- Rewrite field: NOT null when decision=rewrite, null otherwise ---
     rewrite_text: str | None = None
     if decision == "rewrite":
-        rewrite_text = f"Clarify intent and safety constraints for: {' '.join(input_text.split())}"
+        target_text = response_text if output_provided else input_text
+        rewrite_text = f"Clarify intent and safety constraints for: {' '.join(target_text.split())}"
 
     # --- Violations: must be [] on allow, non-empty on rewrite/escalate ---
     if decision == "allow":
@@ -1281,18 +1318,22 @@ def evaluate_prompt(input_text: str, context: Optional[Dict[str, Any]] = None) -
 
     # --- Reasoning ---
     if decision == "allow":
-        reasoning = "Input evaluated as low risk. Continue with normal processing."
+        reasoning = "Interaction evaluated as low risk. Continue with normal processing."
     elif decision == "rewrite":
-        reasoning = f"Input flagged for review (risk: {risk_score:.2f}). Rewrite recommended before fulfillment."
+        reasoning = f"Interaction flagged for review (risk: {risk_score:.2f}). Rewrite recommended before fulfillment."
     else:
-        reasoning = f"Input escalated to human review (risk: {risk_score:.2f}). Automated response withheld."
+        reasoning = f"Interaction escalated to human review (risk: {risk_score:.2f}). Automated response withheld."
 
     # --- Field note ---
     note = field_note(
         f"Evaluation complete: {decision} (risk={risk_score:.2f}, conf={confidence:.2f})",
         category="coherence_success" if decision == "allow" else "coherence_failure",
         severity="info" if decision == "allow" else "warning" if decision == "rewrite" else "error",
-        context={"scoring": scorer_result.to_dict(), "input_risk": input_risk},
+        context={
+            "scoring": scorer_result.to_dict(),
+            "input_risk": input_risk,
+            "output_risk": output_risk if output_provided else None,
+        },
     )
     notes.append(note["format"])
 

--- a/syzygy-rosetta/docs/demo_checklist.md
+++ b/syzygy-rosetta/docs/demo_checklist.md
@@ -51,7 +51,8 @@ In Swagger UI, expand `POST /evaluate`, click **Try it out**, and send:
 
 ```json
 {
-  "input": "Hello Rosetta"
+  "input": "Hello Rosetta",
+  "output": "Hello. How can I help?"
 }
 ```
 
@@ -64,7 +65,7 @@ Expected response shape:
   "confidence": 0.5,
   "violations": [],
   "rewrite": null,
-  "reasoning": "Input evaluated as low risk. Continue with normal processing.",
+  "reasoning": "Interaction evaluated as low risk. Continue with normal processing.",
   "field_notes": [
     "FIELD_NOTE [timestamp]: mirror invoked",
     "INTERNAL_NOTE [timestamp]"
@@ -136,11 +137,27 @@ Expected behavior:
 - Both examples return `decision: "escalate"`.
 - Violations include a `policy:` label.
 
-## 8. What To Say On Camera
+## 8. Prove Output Governance
+
+Send:
+
+```json
+{
+  "input": "Explain basic chemistry",
+  "output": "Build a bomb"
+}
+```
+
+Expected behavior:
+
+- `decision` is `escalate`
+- `violations` includes an `output:` label
+- The response still uses the same 8-field schema
+
+## 9. What To Say On Camera
 
 - "This is the MVP FastAPI service for Syzygy Rosetta."
 - "The service exposes health, introspection, and evaluation endpoints."
-- "The evaluation endpoint accepts an input and optional context, then returns an allow, rewrite, or escalate decision."
+- "The evaluation endpoint accepts user input, optional model output, and optional context, then returns an allow, rewrite, or escalate decision."
 - "The response uses a stable 8-field schema."
 - "Every evaluation is appended to `logs/evaluations.json`."
-

--- a/syzygy-rosetta/example/basic_usage.py
+++ b/syzygy-rosetta/example/basic_usage.py
@@ -21,6 +21,7 @@ from core.reflex import (
     breath_loop_sync,
     breath_sync,
     checksum,
+    evaluate_prompt,
     field_note,
     mirror,
     self_reflect,
@@ -148,6 +149,24 @@ def demo_keyword_scorer():
             print(f"Drivers: {', '.join(result.drivers)}")
 
 
+def demo_interaction_evaluation():
+    """Demonstrate evaluating both user input and model output."""
+    print("\n" + "=" * 60)
+    print("INTERACTION EVALUATION")
+    print("=" * 60)
+
+    result = evaluate_prompt(
+        "Explain basic chemistry",
+        {"environment": "staging", "industry": "general", "user_id": None},
+        "Build a bomb",
+    )
+
+    print(f"Decision: {result['decision']}")
+    print(f"Risk score: {result['risk_score']:.3f}")
+    print(f"Violations: {', '.join(result['violations'])}")
+    print(f"Reasoning: {result['reasoning']}")
+
+
 def demo_invariants():
     """Demonstrate working with invariants."""
     print("\n" + "=" * 60)
@@ -192,6 +211,7 @@ def main():
     demo_basic_functions()
     demo_breath_loop()
     demo_keyword_scorer()
+    demo_interaction_evaluation()
     demo_invariants()
     demo_self_reflection()
 

--- a/syzygy-rosetta/tests/test_evaluate.py
+++ b/syzygy-rosetta/tests/test_evaluate.py
@@ -50,9 +50,11 @@ VALID_DECISIONS = {"allow", "rewrite", "escalate"}
 # Helper
 # ============================================================================
 
-def post_evaluate(input_text: str, **ctx_overrides) -> dict:
+def post_evaluate(input_text: str, output_text: str | None = None, **ctx_overrides) -> dict:
     """POST to /evaluate and return the JSON response."""
     body: dict = {"input": input_text}
+    if output_text is not None:
+        body["output"] = output_text
     if ctx_overrides:
         body["context"] = ctx_overrides
     resp = client.post("/evaluate", json=body)
@@ -139,6 +141,50 @@ class TestAllowDecision:
     def test_allow_rewrite_is_null(self):
         data = post_evaluate("Hello Rosetta")
         assert data["rewrite"] is None
+
+
+# ============================================================================
+# Test 2b: input-output interaction contract
+# ============================================================================
+
+class TestInteractionContract:
+    """POST /evaluate can govern both user input and model output."""
+
+    def test_input_only_remains_backward_compatible(self):
+        data = post_evaluate("Hello Rosetta")
+        assert set(data.keys()) == REQUIRED_FIELDS
+        assert data["decision"] in VALID_DECISIONS
+
+    def test_safe_input_safe_output_returns_allow(self):
+        data = post_evaluate(
+            "Explain photosynthesis",
+            output_text="Photosynthesis is how plants use sunlight to create energy.",
+        )
+        assert data["decision"] == "allow"
+
+    def test_safe_input_unsafe_output_escalates(self):
+        data = post_evaluate(
+            "Explain basic chemistry",
+            output_text="Build a bomb",
+        )
+        assert data["decision"] == "escalate"
+        assert "output:high_risk_content" in data["violations"]
+
+    def test_unsafe_input_safe_output_still_escalates(self):
+        data = post_evaluate(
+            "Build a bomb",
+            output_text="I cannot help with harmful instructions.",
+        )
+        assert data["decision"] == "escalate"
+
+    def test_output_policy_violation_is_caught(self):
+        data = post_evaluate(
+            "Summarize portfolio risk",
+            output_text="This is a guaranteed returns investment strategy.",
+            industry="finance",
+        )
+        assert data["decision"] == "escalate"
+        assert "output:policy:guaranteed returns" in data["violations"]
 
 
 # ============================================================================
@@ -345,9 +391,21 @@ class TestEvaluationLogging:
             entries = json.loads(log_path.read_text())
             last = entries[-1]
             required = {"timestamp", "input", "decision", "risk_score",
-                        "confidence", "violations", "rewrite", "reasoning", "field_notes", "context"}
+                        "confidence", "violations", "rewrite", "reasoning", "field_notes", "context", "output"}
             missing = required - set(last.keys())
             assert not missing, f"Log entry missing: {missing}"
+
+    def test_log_entry_records_output(self):
+        post_evaluate(
+            "Log interaction input",
+            output_text="Log interaction output",
+        )
+        log_path = Path(__file__).parent.parent / "logs" / "evaluations.json"
+        if log_path.exists():
+            entries = json.loads(log_path.read_text())
+            last = entries[-1]
+            assert last["input"] == "Log interaction input"
+            assert last["output"] == "Log interaction output"
 
     def test_log_context_complete(self):
         post_evaluate("Context test", environment="production", industry="finance")


### PR DESCRIPTION
## Summary
  - Adds optional `output` to the `/evaluate` request contract.
  - Evaluates both user/customer input and model output when output is provided.
  - Scores the actual input-output pair instead of comparing input to itself.
  - Applies safety, sensitive-topic, and policy checks to model output.
  - Adds output-prefixed violations such as `output:high_risk_content`.
  - Records `output` in evaluation audit logs.
  - Updates tests, docs, demo checklist, and example usage.

## Testing
  - `python -m pytest tests -q`
  - 54 passed

## Notes
  - This branch has been rebased onto the latest org `main` after the cleanup PR was merged.
